### PR TITLE
Revert "some carriage return ignore fixes"

### DIFF
--- a/packages/framework-integration-tests/integration/provider-unaware/cli/cli.project.integration.ts
+++ b/packages/framework-integration-tests/integration/provider-unaware/cli/cli.project.integration.ts
@@ -189,31 +189,31 @@ describe('Project', () => {
       ['project_name_placeholder', projectName],
     ])
     const cartDemoConfigContent = fileContents('src/config/config.ts')
-    expect(cartDemoConfigContent).to.equal(expectedCartDemoConfig.split('\r\n').join('\n'))
+    expect(cartDemoConfigContent).to.equal(expectedCartDemoConfig)
 
     const expectedCartDemoIndex = loadFixture('cart-demo/src/index.ts')
     const cartDemoIndexContent = fileContents('src/index.ts')
-    expect(cartDemoIndexContent).to.equal(expectedCartDemoIndex.split('\r\n').join('\n'))
+    expect(cartDemoIndexContent).to.equal(expectedCartDemoIndex)
 
     const expectedCartDemoEslintIgnore = loadFixture('cart-demo/.eslintignore')
     const cartDemoEslintIgnoreContent = fileContents('.eslintignore')
-    expect(cartDemoEslintIgnoreContent).to.equal(expectedCartDemoEslintIgnore.split('\r\n').join('\n'))
+    expect(cartDemoEslintIgnoreContent).to.equal(expectedCartDemoEslintIgnore)
 
     const expectedCartDemoEslintRc = loadFixture('cart-demo/.eslintrc.js')
     const cartDemoEslintRcContent = fileContents('.eslintrc.js')
-    expect(cartDemoEslintRcContent).to.equal(expectedCartDemoEslintRc.split('\r\n').join('\n'))
+    expect(cartDemoEslintRcContent).to.equal(expectedCartDemoEslintRc)
 
     const expectedCartDemoGitIgnore = loadFixture('cart-demo/.gitignore')
     const cartDemoGitIgnoreContent = fileContents('.gitignore')
-    expect(cartDemoGitIgnoreContent).to.equal(expectedCartDemoGitIgnore.split('\r\n').join('\n'))
+    expect(cartDemoGitIgnoreContent).to.equal(expectedCartDemoGitIgnore)
 
     const expectedCartDemoPretierRc = loadFixture('cart-demo/.prettierrc.yaml')
     const cartDemoPretierRcContent = fileContents('.prettierrc.yaml')
-    expect(cartDemoPretierRcContent).to.equal(expectedCartDemoPretierRc.split('\r\n').join('\n'))
+    expect(cartDemoPretierRcContent).to.equal(expectedCartDemoPretierRc)
 
     const expectedCartDemoMochaRc = loadFixture('cart-demo/.mocharc.yml')
     const cartDemoMochaRcContent = fileContents('.mocharc.yml')
-    expect(cartDemoMochaRcContent).to.equal(expectedCartDemoMochaRc.split('\r\n').join('\n'))
+    expect(cartDemoMochaRcContent).to.equal(expectedCartDemoMochaRc)
 
     const defaults = flags?.includes('--default')
     const expectedCartDemoPackageJson = loadFixture('cart-demo/package.json', [
@@ -233,11 +233,11 @@ describe('Project', () => {
 
     const expectedCartDemoTsConfigEslint = loadFixture('cart-demo/tsconfig.eslint.json')
     const cartDemoTsConfigEslintContent = fileContents('tsconfig.eslint.json')
-    expect(cartDemoTsConfigEslintContent).to.equal(expectedCartDemoTsConfigEslint.split('\r\n').join('\n'))
+    expect(cartDemoTsConfigEslintContent).to.equal(expectedCartDemoTsConfigEslint)
 
     const expectedCartDemoTsConfig = loadFixture('cart-demo/tsconfig.json')
     const cartDemoTsConfigContent = fileContents('tsconfig.json')
-    expect(cartDemoTsConfigContent).to.equal(expectedCartDemoTsConfig.split('\r\n').join('\n'))
+    expect(cartDemoTsConfigContent).to.equal(expectedCartDemoTsConfig)
   }
 
   context('Valid project', () => {


### PR DESCRIPTION
Reverts nicolatl/booster#5

We want to submit a PR to booster with a cohesive fix; in this case, unittests for Windows. This was work on fixing integration tests, which we couldn't get working.